### PR TITLE
Perform get chat from room

### DIFF
--- a/characterai/characterai.py
+++ b/characterai/characterai.py
@@ -560,7 +560,7 @@ class PyCAI:
             )
 
         def get_chat(
-            self, char: str = None, *,
+            self, char: str = None, history_id: str = None, *,
             wait: bool = False, token: str = None,
             **kwargs
         ):
@@ -568,6 +568,7 @@ class PyCAI:
                 post_link='chat/history/continue/',
                 data={
                     'character_external_id': char,
+                    'history_external_id': history_id,
                     **kwargs
                 },
                 wait=wait, token=token

--- a/characterai/pyasynccai.py
+++ b/characterai/pyasynccai.py
@@ -560,7 +560,7 @@ class PyAsyncCAI:
             )
 
         async def get_chat(
-            self, char: str = None, *,
+            self, char: str = None, history_id: str = None, *,
             wait: bool = False, token: str = None,
             **kwargs
         ):
@@ -568,6 +568,7 @@ class PyAsyncCAI:
                 post_link='chat/history/continue/',
                 data={
                     'character_external_id': char,
+                    'history_external_id': history_id,
                     **kwargs
                 },
                 wait=wait, token=token


### PR DESCRIPTION
This pull request introduces a new feature to retrieve chat messages from chat characters or room. The feature can be used in two ways:

1. **From Chat Character:**
    - You can now fetch chat messages associated with a specific character by using the following code:
        ```python
        await client.chat.get_chat(char="ID")
        ```
        Where `"ID"` represents the character's ID, which can be obtained from the URL parameter `/chat?char=ID`.

2. **From Room Chat:**
    - Additionally, you can retrieve chat messages related to a specific chat history by using this code:
        ```python
        await client.chat.get_chat(history_id="ID")
        ```
        Here, `"ID"` corresponds to the history ID, which can be extracted from the URL parameter `/chat?hist=ID`.

Please review and merge this pull request to incorporate these changes into the codebase.