### PR TITLE
Add the missing websockets package to requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 tls-client>=0.2.2
+websockets~=12.0


### PR DESCRIPTION
`websockets` is used by the package but isn't in the requirements, causing an error if it's not installed manually.